### PR TITLE
[Fix][Shade] Exclude Java 21 multi-release class files from shaded JARs

### DIFF
--- a/seatunnel-shade-arrow/pom.xml
+++ b/seatunnel-shade-arrow/pom.xml
@@ -64,6 +64,7 @@
                                         <exclude>META-INF/*.SF</exclude>
                                         <exclude>META-INF/*.DSA</exclude>
                                         <exclude>META-INF/*.RSA</exclude>
+                                        <exclude>META-INF/versions/21/**</exclude>
                                     </excludes>
                                 </filter>
                             </filters>

--- a/seatunnel-shade-hadoop-aws/pom.xml
+++ b/seatunnel-shade-hadoop-aws/pom.xml
@@ -62,6 +62,7 @@
                                         <exclude>META-INF/*.SF</exclude>
                                         <exclude>META-INF/*.DSA</exclude>
                                         <exclude>META-INF/*.RSA</exclude>
+                                        <exclude>META-INF/versions/21/**</exclude>
                                     </excludes>
                                 </filter>
                             </filters>

--- a/seatunnel-shade-hadoop3-uber/pom.xml
+++ b/seatunnel-shade-hadoop3-uber/pom.xml
@@ -74,6 +74,7 @@
                                         <exclude>META-INF/*.SF</exclude>
                                         <exclude>META-INF/*.DSA</exclude>
                                         <exclude>META-INF/*.RSA</exclude>
+                                        <exclude>META-INF/versions/21/**</exclude>
                                     </excludes>
                                 </filter>
                             </filters>

--- a/seatunnel-shade-jackson/pom.xml
+++ b/seatunnel-shade-jackson/pom.xml
@@ -93,6 +93,7 @@
                                         <exclude>META-INF/*.SF</exclude>
                                         <exclude>META-INF/*.DSA</exclude>
                                         <exclude>META-INF/*.RSA</exclude>
+                                        <exclude>META-INF/versions/21/**</exclude>
                                     </excludes>
                                 </filter>
                             </filters>


### PR DESCRIPTION
Jackson 2.15.4 is a multi-release JAR containing Java 21 optimized classes
(META-INF/versions/21/) with major version 65. The maven-shade-plugin 3.4.1
ASM backend cannot process these files when running on JDK 8, causing build
failure: "Unsupported class file major version 65".

Add <exclude>META-INF/versions/21/**</exclude> to all modules that shade
Jackson 2.15.4:
- seatunnel-shade-hadoop3-uber
- seatunnel-shade-jackson
- seatunnel-shade-hadoop-aws
- seatunnel-shade-arrow

These Java 21 optimization classes are performance improvements only and do
not affect core functionality on JDK 8 runtime.