### PR TITLE
[feature] add seatunnel-shade-jackson-yaml

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,21 +6,22 @@ Each module wraps a single third-party library, relocating its packages under `o
 
 ## Modules
 
-| Module | Library | Version |
-|--------|---------|---------|
-| `seatunnel-shade-hazelcast` | Hazelcast | 5.1 |
-| `seatunnel-shade-hadoop3-uber` | Hadoop Client | 3.1.4 |
-| `seatunnel-shade-jackson` | Jackson | 2.15.4 |
-| `seatunnel-shade-guava` | Guava | 27.0-jre |
-| `seatunnel-shade-hadoop-aws` | Hadoop AWS | 3.1.4 |
-| `seatunnel-shade-arrow` | Apache Arrow | 15.0.1 |
-| `seatunnel-shade-hikari` | HikariCP | 4.0.3 |
+| Module                           | Library | Version |
+|----------------------------------|---------|---------|
+| `seatunnel-shade-hazelcast`      | Hazelcast | 5.1 |
+| `seatunnel-shade-hadoop3-uber`   | Hadoop Client | 3.1.4 |
+| `seatunnel-shade-jackson`        | Jackson | 2.15.4 |
+| `seatunnel-shade-guava`          | Guava | 27.0-jre |
+| `seatunnel-shade-hadoop-aws`     | Hadoop AWS | 3.1.4 |
+| `seatunnel-shade-arrow`          | Apache Arrow | 15.0.1 |
+| `seatunnel-shade-hikari`         | HikariCP | 4.0.3 |
 | `seatunnel-shade-thrift-service` | Apache Doris Thrift | 1.0.0 |
-| `seatunnel-shade-janino` | Janino | 3.1.12 |
+| `seatunnel-shade-janino`         | Janino | 3.1.12 |
 | `seatunnel-shade-scala-compiler` | Scala Compiler | 2.12.15 |
-| `seatunnel-shade-jetty` | Jetty | 9.4.56 |
-| `seatunnel-shade-commons-lang3` | Commons Lang3 | 3.18.0 |
-| `seatunnel-shade-calcite` | Apache Calcite | 1.38.0 |
+| `seatunnel-shade-jetty`          | Jetty | 9.4.56 |
+| `seatunnel-shade-commons-lang3`  | Commons Lang3 | 3.18.0 |
+| `seatunnel-shade-calcite`        | Apache Calcite | 1.38.0 |
+| `seatunnel-shade-jackson-yaml`   | Jackson | 2.15.4 |
 
 ## Build
 

--- a/pom.xml
+++ b/pom.xml
@@ -73,6 +73,7 @@
         <module>seatunnel-shade-jetty</module>
         <module>seatunnel-shade-commons-lang3</module>
         <module>seatunnel-shade-calcite</module>
+        <module>seatunnel-shade-jackson-yaml</module>
     </modules>
 
     <properties>

--- a/seatunnel-shade-jackson-yaml/pom.xml
+++ b/seatunnel-shade-jackson-yaml/pom.xml
@@ -1,0 +1,118 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+    Licensed to the Apache Software Foundation (ASF) under one or more
+    contributor license agreements.  See the NOTICE file distributed with
+    this work for additional information regarding copyright ownership.
+    The ASF licenses this file to You under the Apache License, Version 2.0
+    (the "License"); you may not use this file except in compliance with
+    the License.  You may obtain a copy of the License at
+       http://www.apache.org/licenses/LICENSE-2.0
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>org.apache.seatunnel</groupId>
+        <artifactId>seatunnel-shade</artifactId>
+        <version>3.0.0</version>
+    </parent>
+
+    <artifactId>seatunnel-shade-jackson-yaml</artifactId>
+    <version>${jackson.version}-${seatunnel.shade.version}</version>
+    <name>SeaTunnel : Shade : Jackson YAML</name>
+
+    <dependencies>
+        <!--
+            Jackson YAML is isolated from downstream dependency graphs. The shaded artifact uses
+            the relocated Jackson classes supplied by seatunnel-jackson at runtime.
+        -->
+        <dependency>
+            <groupId>org.apache.seatunnel</groupId>
+            <artifactId>seatunnel-shade-jackson</artifactId>
+            <version>${jackson.version}-${seatunnel.shade.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.dataformat</groupId>
+            <artifactId>jackson-dataformat-yaml</artifactId>
+            <version>${jackson.version}</version>
+            <optional>true</optional>
+            <exclusions>
+                <exclusion>
+                    <groupId>com.fasterxml.jackson.core</groupId>
+                    <artifactId>jackson-databind</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <!-- Keep optional shaded dependencies visible to the license dependency check. -->
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-dependency-plugin</artifactId>
+                <configuration>
+                    <skip>false</skip>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-shade-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>shade</goal>
+                        </goals>
+                        <phase>package</phase>
+                        <configuration>
+                            <finalName>seatunnel-jackson-yaml</finalName>
+                            <createSourcesJar>${enableSourceJarCreation}</createSourcesJar>
+                            <shadeSourcesContent>true</shadeSourcesContent>
+                            <shadedArtifactAttached>false</shadedArtifactAttached>
+                            <createDependencyReducedPom>false</createDependencyReducedPom>
+                            <filters>
+                                <filter>
+                                    <artifact>*:*</artifact>
+                                    <excludes>
+                                        <exclude>META-INF/*.SF</exclude>
+                                        <exclude>META-INF/*.DSA</exclude>
+                                        <exclude>META-INF/*.RSA</exclude>
+                                        <exclude>META-INF/versions/**/module-info.class</exclude>
+                                        <exclude>META-INF/versions/21/**</exclude>
+                                    </excludes>
+                                </filter>
+                                <filter>
+                                    <artifact>org.yaml:snakeyaml</artifact>
+                                    <excludes>
+                                        <!-- Avoid leaking unrelocated multi-release classes. -->
+                                        <exclude>META-INF/versions/**</exclude>
+                                    </excludes>
+                                </filter>
+                            </filters>
+                            <relocations>
+                                <relocation>
+                                    <pattern>com.fasterxml.jackson</pattern>
+                                    <shadedPattern>${seatunnel.shade.package}.com.fasterxml.jackson</shadedPattern>
+                                </relocation>
+                                <relocation>
+                                    <pattern>org.yaml.snakeyaml</pattern>
+                                    <shadedPattern>${seatunnel.shade.package}.org.yaml.snakeyaml</shadedPattern>
+                                </relocation>
+                            </relocations>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>flatten-maven-plugin</artifactId>
+            </plugin>
+        </plugins>
+    </build>
+
+</project>

--- a/seatunnel-shade-jackson-yaml/pom.xml
+++ b/seatunnel-shade-jackson-yaml/pom.xml
@@ -29,7 +29,7 @@
     <dependencies>
         <!--
             Jackson YAML is isolated from downstream dependency graphs. The shaded artifact uses
-            the relocated Jackson classes supplied by seatunnel-jackson at runtime.
+            the relocated Jackson classes supplied by seatunnel-sahde-jackson at runtime.
         -->
         <dependency>
             <groupId>org.apache.seatunnel</groupId>
@@ -40,7 +40,6 @@
             <groupId>com.fasterxml.jackson.dataformat</groupId>
             <artifactId>jackson-dataformat-yaml</artifactId>
             <version>${jackson.version}</version>
-            <optional>true</optional>
             <exclusions>
                 <exclusion>
                     <groupId>com.fasterxml.jackson.core</groupId>
@@ -70,9 +69,6 @@
                         </goals>
                         <phase>package</phase>
                         <configuration>
-                            <finalName>seatunnel-jackson-yaml</finalName>
-                            <createSourcesJar>${enableSourceJarCreation}</createSourcesJar>
-                            <shadeSourcesContent>true</shadeSourcesContent>
                             <shadedArtifactAttached>false</shadedArtifactAttached>
                             <createDependencyReducedPom>false</createDependencyReducedPom>
                             <filters>


### PR DESCRIPTION
## Summary

This PR adds the `seatunnel-shade-jackson-yaml` module to support the standalone SeaTunnel Edge Agent introduced in upstream PR #10879.

### Upstream PR

| PR | Title | 
|----|-------|
| [apache/seatunnel#10879](https://github.com/apache/seatunnel/pull/10879) | [Feature][Zeta] STIP-24 Phase 2: Introduce standalone SeaTunnel Edge Agent MVP and dist integration |

### Changes

**Root `pom.xml`:**
- Add `seatunnel-shade-jackson-yaml` module

**New module: `seatunnel-shade-jackson-yaml`**

Shades `jackson-dataformat-yaml` and its transitive dependency `snakeyaml` under `org.apache.seatunnel.shade.*`. This module is isolated from downstream dependency graphs and depends on the relocated Jackson classes supplied by `seatunnel-shade-jackson` at runtime.